### PR TITLE
allow configuring RestartSec in systemd config

### DIFF
--- a/.config/ansible-lint.yml
+++ b/.config/ansible-lint.yml
@@ -2,6 +2,7 @@
 # .ansible-lint
 exclude_paths:
   - .cache/ # implicit unless exclude_paths is defined in config
+  - .ansible/
   - molecule/
   - .github/
 

--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ This is a ansible collection to set up [vector](https://vector.dev) on various s
 | vector_install_from_repo | no       | false                   | whether to install vector from packages or install from deb or redhat based repositories
 | vector_repo_key          | no       | see `defaults/main.yml` | configurable repo key, in case repo proxy is used
 | vector_repo              | no       | see `defaults/main.yml` | configurable repo, in case repo proxy is used
+| vector_restartsec        | no       |                         | add RestartSec to systemd config
+| vector_systemd_config    | no       |                         | full path of systemd config file (needed for vector_restartsec)
 | vector_package           | no       | vector                  | option to define vector version with package name
 | vector_version           | no       |                         | define vector version while vector is installed by source
 | sources                  | yes      | false                   | ingest observability data from a wide variety of targets [link](https://vector.dev/docs/reference/configuration/sources/)

--- a/README.md
+++ b/README.md
@@ -16,21 +16,22 @@ This is a ansible collection to set up [vector](https://vector.dev) on various s
 
 ## Variables
 
-| Variable                 | Required | Default                 | Description
-|--------------------------|----------|-------------------------|------------
-| vector_template          | yes      | vector.yaml.j2          | path of your vector.yaml template
-| vector_config_file       | yes      | /etc/vector/vector.yaml | system path of your vector.yaml configuration
-| vector_groups            | no       |                         | add user vector to specified groups
-| vector_install_from_repo | no       | false                   | whether to install vector from packages or install from deb or redhat based repositories
-| vector_repo_key          | no       | see `defaults/main.yml` | configurable repo key, in case repo proxy is used
-| vector_repo              | no       | see `defaults/main.yml` | configurable repo, in case repo proxy is used
-| vector_restartsec        | no       |                         | add RestartSec to systemd config
-| vector_systemd_config    | no       |                         | full path of systemd config file (needed for vector_restartsec)
-| vector_package           | no       | vector                  | option to define vector version with package name
-| vector_version           | no       |                         | define vector version while vector is installed by source
-| sources                  | yes      | false                   | ingest observability data from a wide variety of targets [link](https://vector.dev/docs/reference/configuration/sources/)
-| transforms               | no       | false                   | shape your data as it moves through your Vector topology [link](https://vector.dev/docs/reference/configuration/transforms/)
-| sinks                    | yes      | false                   | deliver your observability data to a variety of destinations [link](https://vector.dev/docs/reference/configuration/sinks/)
+| Variable                      | Required | Default                                          | Description
+|-------------------------------|----------|--------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------
+| vector_template               | yes      | vector.yaml.j2                                   | path of your vector.yaml template
+| vector_config_file            | yes      | /etc/vector/vector.yaml                          | system path of your vector.yaml configuration
+| vector_groups                 | no       |                                                  | add user vector to specified groups
+| vector_install_from_repo      | no       | false                                            | whether to install vector from packages or install from deb or redhat based repositories
+| vector_repo_key               | no       | see `defaults/main.yml`                          | configurable repo key, in case repo proxy is used
+| vector_repo                   | no       | see `defaults/main.yml`                          | configurable repo, in case repo proxy is used
+| vector_restartsec             | no       |                                                  | add RestartSec to systemd config
+| vector_restartsec_template    | no       | vector_restartsec.j2                             | path of your vector_restartsec template
+| vector_restartsec_config_file | no       | /etc/systemd/system/vector.service.d/vector.conf | system path of your drop-in vector systemd configuration
+| vector_package                | no       | vector                                           | option to define vector version with package name
+| vector_version                | no       |                                                  | define vector version while vector is installed by source
+| sources                       | yes      | false                                            | ingest observability data from a wide variety of targets [link](https://vector.dev/docs/reference/configuration/sources/)
+| transforms                    | no       | false                                            | shape your data as it moves through your Vector topology [link](https://vector.dev/docs/reference/configuration/transforms/)
+| sinks                         | yes      | false                                            | deliver your observability data to a variety of destinations [link](https://vector.dev/docs/reference/configuration/sinks/)
 
 ## Example for configuration with ansible
 ```yaml

--- a/README.md
+++ b/README.md
@@ -25,9 +25,6 @@ This is a ansible collection to set up [vector](https://vector.dev) on various s
 | vector_repo_key               | no       | see `defaults/main.yml`                          | configurable repo key, in case repo proxy is used
 | vector_repo                   | no       | see `defaults/main.yml`                          | configurable repo, in case repo proxy is used
 | vector_restartsec             | no       |                                                  | add RestartSec to systemd config
-| vector_restartsec_template    | no       | vector_restartsec.j2                             | path of your vector_restartsec template
-| vector_restartsec_config_dir  | no       | /etc/systemd/system/vector.service.d             | path of your drop-in vector systemd configuration
-| vector_restartsec_config_file | no       | vector.conf                                      | file name of your drop-in vector systemd configuration
 | vector_package                | no       | vector                                           | option to define vector version with package name
 | vector_version                | no       |                                                  | define vector version while vector is installed by source
 | sources                       | yes      | false                                            | ingest observability data from a wide variety of targets [link](https://vector.dev/docs/reference/configuration/sources/)

--- a/README.md
+++ b/README.md
@@ -26,7 +26,8 @@ This is a ansible collection to set up [vector](https://vector.dev) on various s
 | vector_repo                   | no       | see `defaults/main.yml`                          | configurable repo, in case repo proxy is used
 | vector_restartsec             | no       |                                                  | add RestartSec to systemd config
 | vector_restartsec_template    | no       | vector_restartsec.j2                             | path of your vector_restartsec template
-| vector_restartsec_config_file | no       | /etc/systemd/system/vector.service.d/vector.conf | system path of your drop-in vector systemd configuration
+| vector_restartsec_config_dir  | no       | /etc/systemd/system/vector.service.d             | path of your drop-in vector systemd configuration
+| vector_restartsec_config_file | no       | vector.conf                                      | file name of your drop-in vector systemd configuration
 | vector_package                | no       | vector                                           | option to define vector version with package name
 | vector_version                | no       |                                                  | define vector version while vector is installed by source
 | sources                       | yes      | false                                            | ingest observability data from a wide variety of targets [link](https://vector.dev/docs/reference/configuration/sources/)

--- a/roles/vector/defaults/main.yml
+++ b/roles/vector/defaults/main.yml
@@ -4,11 +4,6 @@
 vector_template: vector.yaml.j2
 vector_config_file: /etc/vector/vector.yaml
 
-# vector restartsec vector_template
-vector_restartsec_template: vector_restartsec.j2
-vector_restartsec_config_dir: /etc/systemd/system/vector.service.d
-vector_restartsec_config_file: vector.conf
-
 # vector groups
 # vector_groups: []
 

--- a/roles/vector/defaults/main.yml
+++ b/roles/vector/defaults/main.yml
@@ -4,6 +4,10 @@
 vector_template: vector.yaml.j2
 vector_config_file: /etc/vector/vector.yaml
 
+# vector restartsec vector_template
+vector_restartsec_template: vector_restartsec.j2
+vector_restartsec_config_file: /etc/systemd/system/vector.service.d/vector.conf
+
 # vector groups
 # vector_groups: []
 

--- a/roles/vector/defaults/main.yml
+++ b/roles/vector/defaults/main.yml
@@ -6,7 +6,8 @@ vector_config_file: /etc/vector/vector.yaml
 
 # vector restartsec vector_template
 vector_restartsec_template: vector_restartsec.j2
-vector_restartsec_config_file: /etc/systemd/system/vector.service.d/vector.conf
+vector_restartsec_config_dir: /etc/systemd/system/vector.service.d
+vector_restartsec_config_file: vector.conf
 
 # vector groups
 # vector_groups: []

--- a/roles/vector/handlers/main.yml
+++ b/roles/vector/handlers/main.yml
@@ -4,3 +4,7 @@
     state: restarted
     daemon_reload: true
     name: vector
+
+- name: Reload systemd
+  ansible.builtin.systemd_service:
+    daemon_reload: true

--- a/roles/vector/handlers/main.yml
+++ b/roles/vector/handlers/main.yml
@@ -1,10 +1,10 @@
 ---
+- name: Reload systemd
+  ansible.builtin.systemd_service:
+    daemon_reload: true
+
 - name: Restart vector
   ansible.builtin.service:
     state: restarted
     daemon_reload: true
     name: vector
-
-- name: Reload systemd
-  ansible.builtin.systemd_service:
-    daemon_reload: true

--- a/roles/vector/tasks/config.yml
+++ b/roles/vector/tasks/config.yml
@@ -17,7 +17,7 @@
   loop: "{{ vector_groups }}"
   notify: Restart vector
 
-- name: Create a directory for drop-inm configuration if it does not exist
+- name: Create a directory for drop-in configuration if it does not exist
   when:
     - vector_restartsec is defined
   ansible.builtin.file:

--- a/roles/vector/tasks/config.yml
+++ b/roles/vector/tasks/config.yml
@@ -17,12 +17,21 @@
   loop: "{{ vector_groups }}"
   notify: Restart vector
 
+- name: Create a directory for drop-inm configuration if it does not exist
+  when:
+    - vector_restartsec is defined
+  ansible.builtin.file:
+    path: "{{ vector_restartsec_config_dir }}"
+    state: directory
+    owner: root
+    mode: '0755'
+
 - name: Add RestartSec to systemd config
   when:
     - vector_restartsec is defined
   ansible.builtin.template:
     src: "{{ vector_restartsec_template }}"
-    dest: "{{ vector_restartsec_config_file }}"
+    dest: "{{ vector_restartsec_config_dir }}/{{ vector_restartsec_config_file }}"
     owner: root
     group: root
     mode: '0644'

--- a/roles/vector/tasks/config.yml
+++ b/roles/vector/tasks/config.yml
@@ -21,7 +21,7 @@
   when:
     - vector_restartsec is defined
   ansible.builtin.file:
-    path: "{{ vector_restartsec_config_dir }}"
+    path: /etc/systemd/system/vector.service.d
     state: directory
     owner: root
     mode: '0755'
@@ -30,8 +30,8 @@
   when:
     - vector_restartsec is defined
   ansible.builtin.template:
-    src: "{{ vector_restartsec_template }}"
-    dest: "{{ vector_restartsec_config_dir }}/{{ vector_restartsec_config_file }}"
+    src: vector_restartsec.j2
+    dest: /etc/systemd/system/vector.service.d/vector.conf
     owner: root
     group: root
     mode: '0644'

--- a/roles/vector/tasks/config.yml
+++ b/roles/vector/tasks/config.yml
@@ -20,12 +20,13 @@
 - name: Add RestartSec to systemd config
   when:
     - vector_restartsec is defined
-  ansible.builtin.lineinfile:
-    path: "{{ vector_systemd_config }}"
-    regexp: '^RestartSec='
-    line: 'RestartSec={{ vector_restartsec }}'
-    insertafter: '^\[Service\]'
-  notify: Restart vector
+  ansible.builtin.template:
+    src: "{{ vector_restartsec_template }}"
+    dest: "{{ vector_restartsec_config_file }}"
+    owner: root
+    group: root
+    mode: '0644'
+  notify: Reload systemd
 
 - name: Start vector
   ansible.builtin.service:

--- a/roles/vector/tasks/config.yml
+++ b/roles/vector/tasks/config.yml
@@ -21,10 +21,10 @@
   when:
     - vector_restartsec is defined
   ansible.builtin.lineinfile:
-        path: "{{ vector_systemd_config }}"
-        regexp: '^RestartSec='
-        line: 'RestartSec={{ vector_restartsec }}'
-        insertafter: '^\[Service\]'
+    path: "{{ vector_systemd_config }}"
+    regexp: '^RestartSec='
+    line: 'RestartSec={{ vector_restartsec }}'
+    insertafter: '^\[Service\]'
   notify: Restart vector
 
 - name: Start vector

--- a/roles/vector/tasks/config.yml
+++ b/roles/vector/tasks/config.yml
@@ -17,6 +17,16 @@
   loop: "{{ vector_groups }}"
   notify: Restart vector
 
+- name: Add RestartSec to systemd config
+  when:
+    - vector_restartsec is defined
+  ansible.builtin.lineinfile:
+        path: "{{ vector_systemd_config }}"
+        regexp: '^RestartSec='
+        line: 'RestartSec={{ vector_restartsec }}'
+        insertafter: '^\[Service\]'
+  notify: Restart vector
+
 - name: Start vector
   ansible.builtin.service:
     state: started

--- a/roles/vector/templates/vector_restartsec.j2
+++ b/roles/vector/templates/vector_restartsec.j2
@@ -1,0 +1,2 @@
+[Service]
+RestartSec={{ vector_restartsec }}


### PR DESCRIPTION
After a system reboot we observer sometimes failures when starting the vector service, because of too short restart intervalls. To avoid that, I implemented RestartSec Delay in systemd config