### PR TITLE
Separation of repository configuration and installation

### DIFF
--- a/.github/workflows/ansible-lint.yml
+++ b/.github/workflows/ansible-lint.yml
@@ -29,4 +29,4 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
 
       - name: Lint Ansible Playbook
-        uses: ansible/ansible-lint@44be233dbd6a8a6d8f3c5297c318ed4ed4644c32 # v24
+        uses: ansible/ansible-lint@v25.11.0 # 25

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ This is a ansible collection to set up [vector](https://vector.dev) on various s
 | vector_template               | yes      | vector.yaml.j2                                   | path of your vector.yaml template
 | vector_config_file            | yes      | /etc/vector/vector.yaml                          | system path of your vector.yaml configuration
 | vector_groups                 | no       |                                                  | add user vector to specified groups
+| vector_manage_repo            | no       | false                                            | configure deb or redhat based repositories
 | vector_install_from_repo      | no       | false                                            | whether to install vector from packages or install from deb or redhat based repositories
 | vector_repo_key               | no       | see `defaults/main.yml`                          | configurable repo key, in case repo proxy is used
 | vector_repo                   | no       | see `defaults/main.yml`                          | configurable repo, in case repo proxy is used

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -1,7 +1,7 @@
 ---
 namespace: telekom_mms
 name: vector
-version: 1.0.0
+version: 2.0.0
 readme: README.md
 authors:
   - Dimitris Zervas <dzervas@dzervas.gr>

--- a/molecule/vector/converge.yml
+++ b/molecule/vector/converge.yml
@@ -14,6 +14,7 @@
         healthcheck:
           enabled: false
     vector_install_from_repo: true
+    vector_manage_repo: true
   tasks:
     - name: Include role vector
       ansible.builtin.include_role:

--- a/roles/vector/defaults/main.yml
+++ b/roles/vector/defaults/main.yml
@@ -9,6 +9,7 @@ vector_config_file: /etc/vector/vector.yaml
 
 # install vector from repo
 vector_install_from_repo: false
+vector_manage_repo: false
 vector_repo:
   Debian: deb [signed-by=/usr/share/keyrings/datadog-archive-keyring.gpg] https://apt.vector.dev/ stable vector-0
   RedHat: https://yum.vector.dev/stable/vector-0/$basearch/

--- a/roles/vector/tasks/main.yml
+++ b/roles/vector/tasks/main.yml
@@ -1,7 +1,7 @@
 ---
 
 - name: Create repository for debian or redhat based systems
-  when: vector_install_from_repo | bool
+  when: vector_manage_repo | bool
   ansible.builtin.include_tasks: repo.yml
 
 - name: Install vector

--- a/roles/vector/tasks/repo.yml
+++ b/roles/vector/tasks/repo.yml
@@ -24,9 +24,9 @@
       ansible.builtin.shell: |
         set -o pipefail
         curl {{ item }} | gpg --no-default-keyring --keyring /usr/share/keyrings/datadog-archive-keyring.gpg --import --batch
-      register: download_repo_key
+      register: vector_download_repo_key
       changed_when: true
-      failed_when: download_repo_key.rc != 0
+      failed_when: vector_download_repo_key.rc != 0
       args:
         executable: /bin/bash
       loop: "{{ vector_repo_key[ansible_os_family] }}"


### PR DESCRIPTION
Sometimes you want to configure your repositories without using this role. With `vector_manage_repo` is it possible to deactivate repo creation.