### PR TITLE
Update syntax for ansible_facts in tasks to support ansible-core 2.19

### DIFF
--- a/roles/vector/tasks/install.yml
+++ b/roles/vector/tasks/install.yml
@@ -4,23 +4,23 @@
   when: not vector_install_from_repo | bool
   block:
     - name: Install vector (Debian)
-      when: ansible_os_family == 'Debian'
+      when: ansible_facts.os_family == 'Debian'
       ansible.builtin.apt:
         deb: "https://apt.vector.dev/pool/v/ve/vector_{{ vector_version }}-1_{{ arch }}.deb"
         install_recommends: true
       notify: Restart vector
       vars:
-        arch: "{{ vector_arch[ansible_machine] }}"
+        arch: "{{ vector_arch[ansible_facts.machine] }}"
 
     - name: Install vector (RedHat)
-      when: ansible_os_family == 'RedHat'
+      when: ansible_facts.os_family == 'RedHat'
       ansible.builtin.dnf:
         name: "https://yum.vector.dev/stable/vector-0/{{ arch }}/vector-{{ vector_version }}-1.{{ arch }}.rpm"
         state: present
         disable_gpg_check: true # package is not signed
       notify: Restart vector
       vars:
-        arch: "{{ vector_arch[ansible_machine] }}"
+        arch: "{{ vector_arch[ansible_facts.machine] }}"
 
 - name: Install vector from repository
   when: vector_install_from_repo | bool

--- a/roles/vector/tasks/repo.yml
+++ b/roles/vector/tasks/repo.yml
@@ -1,7 +1,7 @@
 ---
 
 - name: Configure repository and Repository key on Debian
-  when: ansible_os_family == "Debian"
+  when: ansible_facts.os_family == "Debian"
   block:
     - name: Ensure apt-transport-https curl and gnupg are installed
       ansible.builtin.apt:
@@ -29,20 +29,20 @@
       failed_when: vector_download_repo_key.rc != 0
       args:
         executable: /bin/bash
-      loop: "{{ vector_repo_key[ansible_os_family] }}"
+      loop: "{{ vector_repo_key[ansible_facts.os_family] }}"
 
     - name: Add vector repository
       ansible.builtin.apt_repository:
-        repo: "{{ vector_repo[ansible_os_family] }}"
+        repo: "{{ vector_repo[ansible_facts.os_family] }}"
         state: present
         filename: vector
 
 - name: Add vector repository for RedHat based distributions
-  when: ansible_os_family == "RedHat"
+  when: ansible_facts.os_family == "RedHat"
   ansible.builtin.yum_repository:
     name: vector
     description: Vector
-    baseurl: "{{ vector_repo[ansible_os_family] }}"
+    baseurl: "{{ vector_repo[ansible_facts.os_family] }}"
     gpgcheck: true
     repo_gpgcheck: "{{ vector_repo_gpgcheck }}"
-    gpgkey: "{{ vector_repo_key[ansible_os_family] }}"
+    gpgkey: "{{ vector_repo_key[ansible_facts.os_family] }}"


### PR DESCRIPTION
Breaking Changes with ansible core 2.19:

INJECT_FACTS_AS_VARS default to True is deprecated, top-level facts will not be auto injected after the change. This feature will be removed from ansible-core version 2.24. INJECT_FACTS_AS_VARS controls whether Ansible Facts are available as top-level variables.



- replace deprecated top level facts beginning with ansible core 2.19