### PR TITLE
dependency on community.general removed since collections can not be refferenced in a role

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -1,7 +1,7 @@
 ---
 namespace: telekom_mms
 name: vector
-version: 2.0.1
+version: 2.0.2
 readme: README.md
 authors:
   - Dimitris Zervas <dzervas@dzervas.gr>

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -12,6 +12,3 @@ galaxy_info:
    This is an ansible collection to set up [vector](https://vector.dev) on various systems.
   license: LICENSE
   min_ansible_version: "2.17"
-dependencies:
-  - name: community.general
-    version: 8.6.0


### PR DESCRIPTION
dependencies in meta/main.yml is interpreted as a role. therefore the installation with `ansible-galaxy install -r requirements.yml` containing our collection telekom_mms.vector is failing.

```
ansible-galaxy install -r requirements.yml
Starting galaxy role install process
- telekom_mms.vector (v2.0.1) was installed successfully
- adding dependency: community.general (8.6.0)
- downloading role 'general', owned by community
[WARNING]: - community.general was NOT installed successfully: - sorry, community.general was not found on [https://galaxy.ansible.com/api/.](https://galaxy.ansible.com/api/)
```